### PR TITLE
Fix null/undefined check in middleware and fix race condition in HttpServerTransport

### DIFF
--- a/src/HttpServerTransport.ts
+++ b/src/HttpServerTransport.ts
@@ -50,17 +50,12 @@ export class HttpServerTransport implements Transport {
   ): Promise<JSONRPCMessage[] | JSONRPCMessage | undefined> => {
     this._startFreshSession();
 
-    jsonRPCMessages.map((message) => {
-      this.onmessage?.(message);
-    });
     const requestMessages = jsonRPCMessages.filter(isRequestMessage);
 
-    if (requestMessages.length === 0) {
-      return;
-    }
+
 
     // Create promises for each request and collect their responses
-    const responseMessages = await Promise.all(
+    const responseMessagesPromises = Promise.all(
       requestMessages.map(
         (requestMessage) =>
           new Promise<JSONRPCMessage>((resolve, reject) => {
@@ -68,6 +63,15 @@ export class HttpServerTransport implements Transport {
           })
       )
     );
+    jsonRPCMessages.map((message) => {
+      this.onmessage?.(message);
+    });
+
+    if (requestMessages.length === 0) {
+      return;
+    }
+    const responseMessages = await responseMessagesPromises
+
 
     return responseMessages.length > 1 ? responseMessages : responseMessages[0];
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ const mcp = ({
     },
     after: async (request) => {
       await serverReady;
-      if (request.response === null || typeof request.response === "string") {
+      if (request.response === null || request.response === undefined || typeof request.response === "string") {
         request.response = { statusCode: 202, body: "" };
       }
 

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -48,7 +48,6 @@ describe("mcp middleware happy path", () => {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
-      // body: JSON.stringify({"jsonrpc":"2.0",method:"ping", id: 12332123 }),
       isBase64Encoded: false,
     } as unknown as APIGatewayProxyEvent;
 

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -40,6 +40,41 @@ describe("mcp middleware happy path", () => {
       id: 123,
     });
   });
+
+  test('should return a 202 when method is not is available', async () => {
+    const event = {
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+      // body: JSON.stringify({"jsonrpc":"2.0",method:"ping", id: 12332123 }),
+      isBase64Encoded: false,
+    } as unknown as APIGatewayProxyEvent;
+
+    const response = await handler(event, defaultContext);
+
+    expect(response).toBeDefined();
+    expect(response.body).toStrictEqual('');
+    expect(response.statusCode).toBe(202);
+  })
+
+  test('should return a 200 with method not found', async () => {
+    const event = {
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized', id:123 }),
+      isBase64Encoded: false,
+    } as unknown as APIGatewayProxyEvent;
+
+    const response = await handler(event, defaultContext);
+
+    expect(response).toBeDefined();
+    expect(JSON.parse(response.body)).toStrictEqual({"jsonrpc":"2.0","id":123,"error":{"code":-32601,"message":"Method not found"}});
+    expect(response.statusCode).toBe(200);
+  })
 });
 
 describe("mcp middleware errors cases", () => {


### PR DESCRIPTION
Hello!
When we try to connect claude with a running serverless application using middy-mcp, we got a 502 errors, claude assumes the mcp server does not work and quits it (although mcp inspector works)

## Issue 1
This is because 
1. Claude  sends a "notification/initialized" jsonrpc call without an id, 
2. in middy after method: `request.response` is `undefined` (not set to `null`)
3. the mcp server does not returning any message
4. `request.response` is undefined instead of set to 202 status code. 
5.  middy transforms this into a 502

When fixing this, we could connect claude with the serverless mcp server.

## Issue 2
Another issue we found was a race condition in HttpServerTransport which calls `onmessage` although the callbacks in `_pendingRequests` are not set yet. This is problematic on the following case:
1. mcp client sends method that is not known
2.  `handleJSONRPCMessages` calls `onmessage`
3. the mcp server synchronously calls `send` although `_pendingRequests` promises are not set


I added a test case for both mentioned issues. 